### PR TITLE
Added Heroic Strike Rank 10 to swing_reset_spells['Warrior']

### DIFF
--- a/WeaponSwingTimer_Core.lua
+++ b/WeaponSwingTimer_Core.lua
@@ -495,7 +495,7 @@ swing_reset_spells['WARRIOR'] = {
     -- --[[ Disarm ]]
     -- --[[ Execute ]]
     -- --[[ Hamstring ]]
-    --[[ Heroic Strike ]]           78, 284, 285, 1608, 11564, 11565, 11566, 11567, 25286, 30324,
+    --[[ Heroic Strike ]]           78, 284, 285, 1608, 11564, 11565, 11566, 11567, 25286, 29707, 30324,
     -- --[[ Intercept ]]
     -- --[[ Intimidating Shout ]]
     -- --[[ Last Stand ]]


### PR DESCRIPTION
Rank 10 of heroic strike is the highest available to warriors in tbc, unlike rank 11 which not obtainable by players in tbc. I've kept Rank 11 in the list of spells, for the sake of completeness, as it does technically exist as a warrior spell in the game.