### PR TITLE
Fix Slam Rank 6

### DIFF
--- a/WeaponSwingTimer_Core.lua
+++ b/WeaponSwingTimer_Core.lua
@@ -515,7 +515,7 @@ swing_reset_spells['WARRIOR'] = {
     -- --[[ Shoot Bow ]]
     -- --[[ Shoot Crossbow ]]
     -- --[[ Shoot Gun ]]
-    --[[ Slam ]]                    1464, 8820, 11604, 11605, 25241
+    --[[ Slam ]]                    1464, 8820, 11604, 11605, 25241, 25242
     -- --[[ Sunder Armor ]]
     -- --[[ Sweeping Strikes ]]
     -- --[[ Taunt ]]


### PR DESCRIPTION
Fixes Slam for BC (Rank 6 learned at level 69)

https://tbc.wowhead.com/spell=25242/slam