### PR TITLE
Calculate correct multishot clipbar width for split mode

### DIFF
--- a/WeaponSwingTimer_Hunter.lua
+++ b/WeaponSwingTimer_Hunter.lua
@@ -432,7 +432,7 @@ addon_data.hunter.UpdateVisualsOnUpdate = function()
                 new_width = settings.width * ((shot_timer - auto_cast_time) / (range_speed - auto_cast_time))
                 if settings.show_multishot_clip_bar then
                     frame.multishot_clip_bar:Show()
-                    multishot_clip_width = math.min((settings.width * 2) * (mult_cast_time / (addon_data.hunter.range_speed)), settings.width)
+                    multishot_clip_width = math.min((settings.width * (range_speed / (range_speed - auto_cast_time))) * (mult_cast_time / (addon_data.hunter.range_speed)), settings.width)
                     frame.multishot_clip_bar:SetWidth(multishot_clip_width)
                 end
             end

--- a/WeaponSwingTimer_Hunter.lua
+++ b/WeaponSwingTimer_Hunter.lua
@@ -432,7 +432,7 @@ addon_data.hunter.UpdateVisualsOnUpdate = function()
                 new_width = settings.width * ((shot_timer - auto_cast_time) / (range_speed - auto_cast_time))
                 if settings.show_multishot_clip_bar then
                     frame.multishot_clip_bar:Show()
-                    multishot_clip_width = math.min((settings.width * (range_speed / (range_speed - auto_cast_time))) * (mult_cast_time / (addon_data.hunter.range_speed)), settings.width)
+                    multishot_clip_width = math.min(settings.width * (mult_cast_time / (range_speed - auto_cast_time)), settings.width)
                     frame.multishot_clip_bar:SetWidth(multishot_clip_width)
                 end
             end


### PR DESCRIPTION
The factor `2` used in calculating the width of the multishot clipbar for the split bar mode is not correct.

The first split bar is 'missing' the autoshot cast time compared the the one bar mode. The clipbar needs to be lengthened by the factor of that 'missing' amount:
```lua
range_speed / (range_speed - auto_cast_time)
```
> `2` would be the factor for a range speed of `2*auto_cast_time = 1.04`

This gives the following equation:
```lua
clipbar_width = bar_width * (range_speed / (range_speed - auto_cast_time)) * (mult_cast_time / range_speed)
```
Which can be simplified to:
```lua
clipbar_width = bar_width * (mult_cast_time / (range_speed - auto_cast_time))
```

__Example:__
```lua
base_weapon_speed = 3
range_speed = 1.5
range_cast_speed_modifer = 0.5 -- range_speed / base_weapon_speed
auto_cast_time = 0.26 -- 0.52 * range_cast_speed_modifer
mult_cast_time = 0.25 -- 0.50 * range_cast_speed_modifer
-- the bar width is set so a pixel represents 0.01s for the first bar
bar_width  = 124 -- (range_speed - auto_cast_time) * 100
-- the shot_timer at the time when it is still save to cast multishot is auto_cast_time + mult_cast_time = 0.51
-- the current_bar_width at that time is therefore the following:
current_bar_width = bar_width * ((shot_timer - auto_cast_time) / (range_speed - auto_cast_time))
current_bar_width = 124 * ((0.51 - 0.26) / (1.5 - 0.26)) 
current_bar_width = 25
-- hence the clipbar_width needs to be 25 as well
clipbar_width = bar_width * (mult_cast_time / (range_speed - auto_cast_time))
clipbar_width = 124 * (0.25 / (1.5 - 0.26))
clipbar_width = 25
```

> For anyone curious, of the difference to a constant factor of `2`. The `clipbar_width` would have the following values:
> ``` lua
> -- bar_width always adjusted so 1 pixel represents ~0.01s for the first bar
> -------------------------------------------------
> base_weapon_speed = 3
> range_speed = 1.5
> bar_width = 124
> clipbar_width = 41 -- 160ms to early
> -------------------------------------------------
> base_weapon_speed = 2.9
> range_speed = 2.9
> bar_width = 238
> clipbar_width = 82 -- should be 50, 320ms to early
> -------------------------------------------------
> base_weapon_speed = 2.9
> range_speed = 2.1
> bar_width = 172
> clipbar_width = 59 -- should be 36, 230ms to early
> -------------------------------------------------
> base_weapon_speed = 2.9
> range_speed = 1.8
> bar_width = 148
> clipbar_width = 51 -- should be 31, 200ms to early
> ```
> As `2.9` base and `2.1` speed are probably the most common cases, the quarter of a second probably isn't all that noticeable. I only noticed this when I added a steady shot clip bar (using the same equation) and was surprised that it always encompassed the entire bar, which was obviously wrong. The PR #42 suffers from the same all encompassing steady shot clip bar in split bar mode, due to using the same equation with factor `2`.