### PR TITLE
Updates to use Backdrop changes from WoW 9.0.1

### DIFF
--- a/WeaponSwingTimer_Config.lua
+++ b/WeaponSwingTimer_Config.lua
@@ -71,7 +71,7 @@ addon_data.config.CheckBoxFactory = function(g_name, parent, checkbtn_text, tool
 end
 
 addon_data.config.EditBoxFactory = function(g_name, parent, title, w, h, enter_func)
-    local edit_box_obj = CreateFrame("EditBox", addon_name .. g_name, parent)
+    local edit_box_obj = CreateFrame("EditBox", addon_name .. g_name, parent, BackdropTemplateMixin and "BackdropTemplate")
     edit_box_obj.title_text = addon_data.config.TextFactory(edit_box_obj, title, 12)
     edit_box_obj.title_text:SetPoint("TOP", 0, 12)
     edit_box_obj:SetBackdrop({

--- a/WeaponSwingTimer_Hunter.lua
+++ b/WeaponSwingTimer_Hunter.lua
@@ -810,7 +810,7 @@ addon_data.hunter.InitializeVisuals = function()
     frame:SetScript("OnDragStart", addon_data.hunter.OnFrameDragStart)
     frame:SetScript("OnDragStop", addon_data.hunter.OnFrameDragStop)
     -- Create the backplane
-    frame.backplane = CreateFrame("Frame", addon_name .. "HunterBackdropFrame", frame)
+    frame.backplane = CreateFrame("Frame", addon_name .. "HunterBackdropFrame", frame, BackdropTemplateMixin and "BackdropTemplate")
     frame.backplane:SetPoint('TOPLEFT', -9, 9)
     frame.backplane:SetPoint('BOTTOMRIGHT', 9, -9)
     frame.backplane:SetFrameStrata('BACKGROUND')

--- a/WeaponSwingTimer_Player.lua
+++ b/WeaponSwingTimer_Player.lua
@@ -414,7 +414,7 @@ addon_data.player.InitializeVisuals = function()
     frame:SetScript("OnDragStart", addon_data.player.OnFrameDragStart)
     frame:SetScript("OnDragStop", addon_data.player.OnFrameDragStop)
     -- Create the backplane and border
-    frame.backplane = CreateFrame("Frame", addon_name .. "PlayerBackdropFrame", frame)
+    frame.backplane = CreateFrame("Frame", addon_name .. "PlayerBackdropFrame", frame, BackdropTemplateMixin and "BackdropTemplate")
     frame.backplane:SetPoint('TOPLEFT', -9, 9)
     frame.backplane:SetPoint('BOTTOMRIGHT', 9, -9)
     frame.backplane:SetFrameStrata('BACKGROUND')

--- a/WeaponSwingTimer_Target.lua
+++ b/WeaponSwingTimer_Target.lua
@@ -441,7 +441,7 @@ addon_data.target.InitializeVisuals = function()
     frame:SetScript("OnDragStart", addon_data.target.OnFrameDragStart)
     frame:SetScript("OnDragStop", addon_data.target.OnFrameDragStop)
     -- Create the backplane
-    frame.backplane = CreateFrame("Frame", addon_name .. "TargetBackdropFrame", frame)
+    frame.backplane = CreateFrame("Frame", addon_name .. "TargetBackdropFrame", frame, BackdropTemplateMixin and "BackdropTemplate")
     frame.backplane:SetPoint('TOPLEFT', -9, 9)
     frame.backplane:SetPoint('BOTTOMRIGHT', 9, -9)
     frame.backplane:SetFrameStrata('BACKGROUND')


### PR DESCRIPTION
Uses BackdropTemplateMixin and template system introduced in WoW version 9.0.1,
which eliminated Backdrop related APIs on frames by default.

This commit resolves "attempt to call method 'SetBackdrop' (a nil value)" errs

From example listed at https://github.com/Stanzilla/WoWUIBugs/wiki/9.0.1-Consolidated-UI-Changes#lua-changes