### PR TITLE
Fix Master Spellstone crash

### DIFF
--- a/WeaponSwingTimer_Hunter.lua
+++ b/WeaponSwingTimer_Hunter.lua
@@ -183,8 +183,8 @@ addon_data.hunter.UpdateRangeCastSpeedModifier = function()
 		end
 	else
 		range_speed, _, _, _, _, _ = UnitRangedDamage("player")
-		-- added case for if range speed returns nil or 0
-		if range_speed == nil or range_speed == 0 then
+		-- added case for if range speed returns nil or 0, or base_speed is zero (Master Spellstone)
+		if range_speed == nil or range_speed == 0 or addon_data.hunter.base_speed == 0 then
 			range_speed = 1
 		else
 			addon_data.hunter.range_cast_speed_modifer = range_speed / addon_data.hunter.base_speed

--- a/WeaponSwingTimer_ranged_DB.lua
+++ b/WeaponSwingTimer_ranged_DB.lua
@@ -386,6 +386,7 @@ addon_data.ranged_DB.item_ids = {
 	[22318] = {base_speed = 2.9},    -- Malgen's Long Bow
 	[22347] = {base_speed = 3.2},    -- Fahrad's Reloading Repeater
 	[22408] = {base_speed = 1.3},    -- Ritssyn's Wand of Bad Mojo
+	[22646] = {base_speed = 0},    -- Master Spellstone
 	[22656] = {base_speed = 3},    -- The Purifier
 	[22810] = {base_speed = 2},    -- Toxin Injector
 	[22811] = {base_speed = 2.9},    -- Soulstring


### PR DESCRIPTION
Item has no swing timer and noticed a table lookup was constantly failing in pvp.