### PR TITLE
Added missing heirloom weapon ids

### DIFF
--- a/WeaponSwingTimer_ranged_DB.lua
+++ b/WeaponSwingTimer_ranged_DB.lua
@@ -1056,4 +1056,6 @@ addon_data.ranged_DB.item_ids = {
     [36630] = {base_speed = 2.7},          --  Sinewed Crossbow
     [37018] = {base_speed = 3},            --  G.E.H.T.A.
 	[199714] = {base_speed = 2.7},     	   --  Collective Bow
+	[42946] = {base_speed = 2.8},     	   --  Charmed Ancient Bone Bow
+	[44093] = {base_speed = 2.9},     	   --  Upgraded Dwarven Hand Cannon
 }


### PR DESCRIPTION
Equipping heirlooms currently throws ~60 errors/second because the IDs are missing from the database. This PR adds the IDs for both heirlooms

![image](https://user-images.githubusercontent.com/47432804/197633205-9c958fa7-452c-40b7-abdc-0fbc5a6f8cd8.png)
![image](https://user-images.githubusercontent.com/47432804/197633228-4f10ce88-aafe-44eb-90a8-1ced6b8be0d5.png)
