### PR TITLE
Fix 1.15.4: Interface setting, inaccessible globals.

### DIFF
--- a/WeaponSwingTimer.toc
+++ b/WeaponSwingTimer.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11504
 ## Title-deDE: WeaponSwingTimer (Deutsch)
 ## Title-enUS: WeaponSwingTimer (English)
 ## Title-esES: WeaponSwingTimer (Español)

--- a/WeaponSwingTimer_Config.lua
+++ b/WeaponSwingTimer_Config.lua
@@ -25,7 +25,9 @@ addon_data.config.InitializeVisuals = function()
 
     panel.name = "WeaponSwingTimer"
     panel.default = addon_data.config.OnDefault
-    InterfaceOptions_AddCategory(panel)
+    local category = Settings.RegisterCanvasLayoutCategory(panel, panel.name)
+    category.ID = panel.name
+    Settings.RegisterAddOnCategory(category)
     
     -- Add the melee panel
     panel.config_melee_panel = CreateFrame("Frame", nil, panel)
@@ -39,7 +41,7 @@ addon_data.config.InitializeVisuals = function()
     panel.config_melee_panel.name = L["Melee Settings"]
     panel.config_melee_panel.parent = panel.name
     panel.config_melee_panel.default = addon_data.config.OnDefault
-    InterfaceOptions_AddCategory(panel.config_melee_panel)
+    Settings.RegisterCanvasLayoutSubcategory(category, panel.config_melee_panel, panel.config_melee_panel.name)
     
     -- Add the hunter panel
     panel.config_hunter_panel = CreateFrame("Frame", nil, panel)
@@ -53,7 +55,7 @@ addon_data.config.InitializeVisuals = function()
     panel.config_hunter_panel.name = L["Hunter & Wand Settings"]
     panel.config_hunter_panel.parent = panel.name
     panel.config_hunter_panel.default = addon_data.config.OnDefault
-    InterfaceOptions_AddCategory(panel.config_hunter_panel)
+    Settings.RegisterCanvasLayoutSubcategory(category, panel.config_hunter_panel, panel.config_hunter_panel.name)
     
 
 end
@@ -118,14 +120,6 @@ addon_data.config.SliderFactory = function(g_name, parent, title, min_val, max_v
     local editbox = CreateFrame("EditBox", "$parentEditBox", slider, "InputBoxTemplate")
     slider:SetMinMaxValues(min_val, max_val)
     slider:SetValueStep(val_step)
-    slider.text = _G[addon_name .. g_name .. "Text"]
-    slider.text:SetText(title)
-    slider.textLow = _G[addon_name .. g_name .. "Low"]
-    slider.textHigh = _G[addon_name .. g_name .. "High"]
-    slider.textLow:SetText(floor(min_val))
-    slider.textHigh:SetText(floor(max_val))
-    slider.textLow:SetTextColor(0.8,0.8,0.8)
-    slider.textHigh:SetTextColor(0.8,0.8,0.8)
     slider:SetObeyStepOnDrag(true)
     editbox:SetSize(45,30)
     editbox:ClearAllPoints()

--- a/WeaponSwingTimer_Core.lua
+++ b/WeaponSwingTimer_Core.lua
@@ -748,8 +748,7 @@ SLASH_WEAPONSWINGTIMER_CONFIG1 = "/WeaponSwingTimer"
 SLASH_WEAPONSWINGTIMER_CONFIG2 = "/weaponswingtimer"
 SLASH_WEAPONSWINGTIMER_CONFIG3 = "/wst"
 SlashCmdList["WEAPONSWINGTIMER_CONFIG"] = function(option)
-    InterfaceOptionsFrame_OpenToCategory("WeaponSwingTimer")
-    InterfaceOptionsFrame_OpenToCategory("WeaponSwingTimer")
+    Settings.OpenToCategory("WeaponSwingTimer")
 end
 
 -- Setup the core of the addon (This is like calling main in C)


### PR DESCRIPTION
I've done my best to resolve for the breaking changes blizzard made. It appeared there were some unused variables, so I've removed them, and accessed the interface settings using the Settings object instead of the other way.

Resolves #72