### PR TITLE
Fix Classic Era 1.15.9 settings category opening

### DIFF
--- a/WeaponSwingTimer.toc
+++ b/WeaponSwingTimer.toc
@@ -1,4 +1,4 @@
-## Interface: 11508
+## Interface: 11509
 ## Title-deDE: WeaponSwingTimer (Deutsch)
 ## Title-enUS: WeaponSwingTimer (English)
 ## Title-esES: WeaponSwingTimer (Español)

--- a/WeaponSwingTimer_Config.lua
+++ b/WeaponSwingTimer_Config.lua
@@ -26,7 +26,7 @@ addon_data.config.InitializeVisuals = function()
     panel.name = "WeaponSwingTimer"
     panel.default = addon_data.config.OnDefault
     local category = Settings.RegisterCanvasLayoutCategory(panel, panel.name)
-    category.ID = panel.name
+    addon_data.config.category = category
     Settings.RegisterAddOnCategory(category)
     
     -- Add the melee panel

--- a/WeaponSwingTimer_Core.lua
+++ b/WeaponSwingTimer_Core.lua
@@ -884,8 +884,8 @@ SLASH_WEAPONSWINGTIMER_CONFIG1 = "/WeaponSwingTimer"
 SLASH_WEAPONSWINGTIMER_CONFIG2 = "/weaponswingtimer"
 SLASH_WEAPONSWINGTIMER_CONFIG3 = "/wst"
 SlashCmdList["WEAPONSWINGTIMER_CONFIG"] = function(option)
-    if Settings and Settings.OpenToCategory then
-        Settings.OpenToCategory("WeaponSwingTimer")
+    if Settings and Settings.OpenToCategory and addon_data.config.category then
+        Settings.OpenToCategory(addon_data.config.category:GetID())
     elseif InterfaceOptionsFrame_OpenToCategory then
         -- Fallback for older clients (called twice to work around a known bug)
         InterfaceOptionsFrame_OpenToCategory("WeaponSwingTimer")


### PR DESCRIPTION
## Summary

- keep the registered Settings category object instead of overwriting its ID with a string
- open `/wst` using the numeric category ID returned by `category:GetID()`
- retain the legacy double `InterfaceOptionsFrame_OpenToCategory` fallback
- update the Classic Era interface version to `11509`

## Problem

On Classic Era 1.15.9, `/wst` passes `"WeaponSwingTimer"` to `Settings.OpenToCategory`. The current Settings API expects a numeric category ID and raises:

```
bad argument #1 to 'OpenSettingsPanel'
```

The category returned by `Settings.RegisterCanvasLayoutCategory` already owns the correct ID, so the slash command now stores that category and uses `GetID()` when opening it.

## Verification

- tested in game on Classic Era 1.15.9: the addon loads, `/wst` opens the settings page, and its settings tabs work
- confirmed the legacy options fallback is unchanged
- confirmed the category is registered before the slash command can be used
- `git diff --check` passes